### PR TITLE
base: Add special captive portal servers for Chinese

### DIFF
--- a/services/core/java/com/android/server/connectivity/NetworkMonitor.java
+++ b/services/core/java/com/android/server/connectivity/NetworkMonitor.java
@@ -29,6 +29,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Resources;
 import android.net.CaptivePortal;
 import android.net.ConnectivityManager;
 import android.net.ICaptivePortal;
@@ -89,6 +90,8 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.text.DecimalFormat;
+import java.util.Locale;
 
 /**
  * {@hide}
@@ -110,6 +113,10 @@ public class NetworkMonitor extends StateMachine {
     private static final String DEFAULT_USER_AGENT    = "Mozilla/5.0 (X11; Linux x86_64) "
                                                       + "AppleWebKit/537.36 (KHTML, like Gecko) "
                                                       + "Chrome/60.0.3112.32 Safari/537.36";
+
+    private static final String DEFAULT_HTTPS_URL_CN     = "https://captive.v2ex.co/generate_204";
+    private static final String DEFAULT_HTTP_URL_CN      = "http://captive.v2ex.co/generate_204";
+    private static final String DEFAULT_FALLBACK_URL_CN  = "http://g.cn/generate_204";
 
     private static final int SOCKET_TIMEOUT_MS = 10000;
     private static final int PROBE_TIMEOUT_MS  = 3000;
@@ -864,6 +871,12 @@ public class NetworkMonitor extends StateMachine {
         }
     }
 
+        private static boolean isChinese() {
+        Locale locale = Resources.getSystem().getConfiguration().locale;
+        return locale.getLanguage().startsWith(Locale.CHINESE.getLanguage())
+                && !locale.getCountry().equals("TW");
+    }
+
     public boolean getIsCaptivePortalCheckEnabled() {
         String symbol = Settings.Global.CAPTIVE_PORTAL_MODE;
         int defaultValue = Settings.Global.CAPTIVE_PORTAL_MODE_PROMPT;
@@ -881,7 +894,8 @@ public class NetworkMonitor extends StateMachine {
 
     private String getCaptivePortalServerHttpsUrl() {
         return mSettings.getSetting(mContext,
-                Settings.Global.CAPTIVE_PORTAL_HTTPS_URL, DEFAULT_HTTPS_URL);
+                Settings.Global.CAPTIVE_PORTAL_HTTPS_URL,
+                isChinese() ? DEFAULT_HTTPS_URL_CN : DEFAULT_HTTPS_URL); 
     }
 
     // Static for direct access by ConnectivityService
@@ -891,15 +905,15 @@ public class NetworkMonitor extends StateMachine {
 
     public static String getCaptivePortalServerHttpUrl(
             NetworkMonitorSettings settings, Context context) {
-        return settings.getSetting(
-                context, Settings.Global.CAPTIVE_PORTAL_HTTP_URL, DEFAULT_HTTP_URL);
+        return settings.getSetting(context, Settings.Global.CAPTIVE_PORTAL_HTTP_URL,
+                                  isChinese() ? DEFAULT_HTTP_URL_CN : DEFAULT_HTTP_URL);
     }
 
     private URL[] makeCaptivePortalFallbackUrls() {
         try {
             String separator = ",";
             String firstUrl = mSettings.getSetting(mContext,
-                    Settings.Global.CAPTIVE_PORTAL_FALLBACK_URL, DEFAULT_FALLBACK_URL);
+                    Settings.Global.CAPTIVE_PORTAL_FALLBACK_URL, isChinese() ? DEFAULT_FALLBACK_URL_CN : DEFAULT_FALLBACK_URL);
             String joinedUrls = firstUrl + separator + mSettings.getSetting(mContext,
                     Settings.Global.CAPTIVE_PORTAL_OTHER_FALLBACK_URLS,
                     DEFAULT_OTHER_FALLBACK_URLS);


### PR DESCRIPTION
as we all know,google.com has been banned in China. So we who are in China cant
connect to the CaptivePortal server,then All networks (wifi, mobile data) are mistakenly
detected as having no network connection
This solution sets the appropriate server by detecting the system default language